### PR TITLE
Added Backup texts for profile

### DIFF
--- a/src/app/profile/user/details/details.component.html
+++ b/src/app/profile/user/details/details.component.html
@@ -120,11 +120,21 @@
               >
             </div>
             <div class="main-info__projects">
-              <div class="project_card" *ngFor="let project of userProjects">
-                <div class="project_card--header">{{ project.project_name }} | {{ project.current_stage }}</div>
-                <div class="project_card--body">{{ project.description }}</div>
-                <a class="expand" [routerLink]="['/view/project', project.id]"><mat-icon>open_in_new</mat-icon></a>
+              <div *ngIf="!userProjects?.length > 0; else elseBlock">
+                <div *ngIf="isSameUser; else notsameuser">
+                  <p>Nothing to show</p>
+                  <br /><button routerLink="/add/project" mat-raised-button>Add projects</button>
+                </div>
+                <ng-template #notsameuser> No projects to show </ng-template>
               </div>
+
+              <ng-template #elseBlock>
+                <div class="project_card" *ngFor="let project of userProjects">
+                  <div class="project_card--header">{{ project.project_name }} | {{ project.current_stage }}</div>
+                  <div class="project_card--body">{{ project.description }}</div>
+                  <a class="expand" [routerLink]="['/view/project', project.id]"><mat-icon>open_in_new</mat-icon></a>
+                </div>
+              </ng-template>
             </div>
           </span>
 

--- a/src/app/profile/user/details/details.component.html
+++ b/src/app/profile/user/details/details.component.html
@@ -145,11 +145,21 @@
               <!--goes to idea/feed with filter of this user's username-->
             </div>
             <div class="main-info__projects">
-              <div class="project_card" *ngFor="let idea of userIdeas">
-                <div class="project_card--header">{{ idea.idea_name }}</div>
-                <div class="project_card--body">{{ idea.description }}</div>
-                <a><mat-icon class="expand" (click)="openDialog(idea)">open_in_new</mat-icon></a>
+              <div *ngIf="!userIdeas?.length > 0; else elseBlock">
+                <div *ngIf="isSameUser; else notsameuser">
+                  <p>Nothing to show</p>
+                  <br /><button routerLink="/add/idea" mat-raised-button>Add Ideas</button>
+                </div>
+                <ng-template #notsameuser> No Ideas to show </ng-template>
               </div>
+
+              <ng-template #elseBlock>
+                <div class="project_card" *ngFor="let idea of userIdeas">
+                  <div class="project_card--header">{{ idea.idea_name }}</div>
+                  <div class="project_card--body">{{ idea.description }}</div>
+                  <a><mat-icon class="expand" (click)="openDialog(idea)">open_in_new</mat-icon></a>
+                </div>
+              </ng-template>
             </div>
           </span>
         </div>

--- a/src/app/profile/user/details/details.component.html
+++ b/src/app/profile/user/details/details.component.html
@@ -120,15 +120,15 @@
               >
             </div>
             <div class="main-info__projects">
-              <div *ngIf="!userProjects?.length > 0; else elseBlock">
-                <div *ngIf="isSameUser; else notsameuser">
+              <div *ngIf="!userProjects?.length > 0; else ProjectCreated">
+                <div *ngIf="isSameUser; else isDifferentUser">
                   <p>Nothing to show</p>
                   <br /><button routerLink="/add/project" mat-raised-button>Add projects</button>
                 </div>
-                <ng-template #notsameuser> No projects to show </ng-template>
+                <ng-template #isDifferentUser> No projects to show </ng-template>
               </div>
 
-              <ng-template #elseBlock>
+              <ng-template #ProjectCreated>
                 <div class="project_card" *ngFor="let project of userProjects">
                   <div class="project_card--header">{{ project.project_name }} | {{ project.current_stage }}</div>
                   <div class="project_card--body">{{ project.description }}</div>
@@ -145,15 +145,15 @@
               <!--goes to idea/feed with filter of this user's username-->
             </div>
             <div class="main-info__projects">
-              <div *ngIf="!userIdeas?.length > 0; else elseBlock">
-                <div *ngIf="isSameUser; else notsameuser">
+              <div *ngIf="!userIdeas?.length > 0; else IdeasCreated">
+                <div *ngIf="isSameUser; else isDifferentUser">
                   <p>Nothing to show</p>
                   <br /><button routerLink="/add/idea" mat-raised-button>Add Ideas</button>
                 </div>
-                <ng-template #notsameuser> No Ideas to show </ng-template>
+                <ng-template #isDifferentUser> No Ideas to show </ng-template>
               </div>
 
-              <ng-template #elseBlock>
+              <ng-template #IdeasCreated>
                 <div class="project_card" *ngFor="let idea of userIdeas">
                   <div class="project_card--header">{{ idea.idea_name }}</div>
                   <div class="project_card--body">{{ idea.description }}</div>


### PR DESCRIPTION
fixes #87
Changes done: ( Common for both Idea and project section) - The same user sees the Add buttons when there is no project/idea. If the user visits someone with no project/idea he see Nothing to show. 
I am attaching appropriate SS.

1. Logged as Manthan visiting m.
![2](https://user-images.githubusercontent.com/42006277/52562091-579ab300-2e23-11e9-83ed-2e2c414ee479.png)
2.Logged in as Manthan visiting Manthan
![3](https://user-images.githubusercontent.com/42006277/52562092-579ab300-2e23-11e9-94a8-f4acf59da896.png)
3, Logged in as Manthan visiting Aayush
![4](https://user-images.githubusercontent.com/42006277/52562094-58334980-2e23-11e9-95f7-690691f36240.png)
4. Logged in as M visiting M ( new account ) 
![1](https://user-images.githubusercontent.com/42006277/52562090-57021c80-2e23-11e9-936a-6b2a7b13737b.png)
