### PR TITLE
Removed Excess padding in view idea modal

### DIFF
--- a/src/app/view/feed/idea-feed/idea-feed.component.ts
+++ b/src/app/view/feed/idea-feed/idea-feed.component.ts
@@ -18,6 +18,7 @@ export class IdeaFeedComponent implements OnInit {
 
   openDialog(idea: any): void {
     const dialogRef = this.dialog.open(IdeaCardComponent, {
+      panelClass: 'custom-dialog-container',
       width: 'auto',
       data: { idea }
     });
@@ -33,8 +34,10 @@ export class IdeaFeedComponent implements OnInit {
   }
 
   getIdeasFromServer(event: any) {
-    this.ideaService.getNIdeas(event.pageSize, event.pageIndex).subscribe(data => {
-      this.ideaList = data.data.ideas;
-    });
+    this.ideaService
+      .getNIdeas(event.pageSize, event.pageIndex)
+      .subscribe(data => {
+        this.ideaList = data.data.ideas;
+      });
   }
 }

--- a/src/main.scss
+++ b/src/main.scss
@@ -100,3 +100,8 @@ body {
   font-size: 1rem;
   font-style: italic;
 }
+
+// overriding  mat-dialog-container
+.custom-dialog-container .mat-dialog-container {
+  padding: 0;
+}


### PR DESCRIPTION
Fixes #140
removed the padding property of mat-dialog by overriding its property and made changes in files
-> src/main.scss
    
-> idea-feed.component.ts
        added  'panelClass' property in the openDialog function 